### PR TITLE
manually add GitHub Actions config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on:
+      - ubuntu-latest
+
+    env:
+      TRAVIS_OS_NAME: linux
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Get package script
+      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+
+    - name: Set script permissions
+      run: chmod u+x build-package.sh
+
+    - name: Build package
+      run: ./build-package.sh
+
+  build-macos:
+    runs-on:
+      - macOS-latest
+
+    env:
+      TRAVIS_OS_NAME: osx
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Get package script
+      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+
+    - name: Set script permissions
+      run: chmod u+x build-package.sh
+
+    - name: Build package
+      run: ./build-package.sh


### PR DESCRIPTION
GitHub Actions prevents workflow configurations from being pushed with git, so update this manually